### PR TITLE
Bumping php system requirement to >= 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "MIT",
     "homepage": "https://laratranslate.com/",
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.4",
         "ext-curl": "*",
         "ext-json": "*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,19 +4,19 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33fce588ab23b785afe236adbd209294",
+    "content-hash": "ff0c0c49bce2bf2b3dba05fd3988c20e",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6.0",
+        "php": ">=7.4",
         "ext-curl": "*",
         "ext-json": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Hello!

I was browsing the source to try and get a handle on Lara's API and noticed the [README PHP version requirement states](https://github.com/translated/lara-php/blob/main/README.md?plain=1#L354) >= 7.4 while `composer.json` [enforced >=5.6.0](https://github.com/translated/lara-php/blob/main/composer.json#L15), so I thought I'd PR a fix reflective of the documentation.

I haven't run or tested this, I just wanted to bring it to your attention and if this fix is acceptable, great.