### PR TITLE
Fix Object Operator typo

### DIFF
--- a/src/Documents.php
+++ b/src/Documents.php
@@ -103,7 +103,7 @@ class Documents
     {
         $documentUploadOptions = new DocumentUploadOptions();
         if ($options->getAdaptTo())
-            $documentUploadOptions.setAdaptTo($options->getAdaptTo());
+            $documentUploadOptions->setAdaptTo($options->getAdaptTo());
         if ($options->isNoTrace())
             $documentUploadOptions->setNoTrace($options->isNoTrace());
         if ($options->getGlossaries())


### PR DESCRIPTION
Found a typo while browsing the code:

`$documentUploadOptions.setAdaptTo($options->getAdaptTo());`
should be:
`$documentUploadOptions->setAdaptTo($options->getAdaptTo());`